### PR TITLE
feat: Add /tasks endpoint with Kafka integration

### DIFF
--- a/agent_orchestrator/app/kafka/producer.py
+++ b/agent_orchestrator/app/kafka/producer.py
@@ -1,11 +1,18 @@
+# agent_orchestrator/app/kafka/producer.py
+
 import json
 import time
 import os
 from kafka import KafkaProducer
+from ..orchestrator.task_model import AgentTask
 
 KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
+TOPIC_IN = os.getenv("TOPIC_IN", "agent-tasks-inbound")
+
+producer = None  # Global producer instance
 
 def init_kafka_producer():
+    global producer
     for attempt in range(10):
         try:
             producer = KafkaProducer(
@@ -18,3 +25,9 @@ def init_kafka_producer():
             print(f"[Kafka] Attempt {attempt + 1} failed: {e}", flush=True)
             time.sleep(3)
     raise RuntimeError("Kafka unavailable after retries")
+
+def produce_task(task: AgentTask):
+    if producer is None:
+        raise RuntimeError("Kafka producer not initialized.")
+    producer.send(TOPIC_IN, task.dict())
+    print(f"[Kafka] Task {task.id} sent to {TOPIC_IN}", flush=True)

--- a/agent_orchestrator/app/orchestrator/agent_router.py
+++ b/agent_orchestrator/app/orchestrator/agent_router.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, HTTPException
+from ..orchestrator.orchestrator_engine import OrchestrationEngine
+from ..orchestrator.task_model import AgentTask
+
+router = APIRouter()
+
+@router.post("/tasks")
+async def create_task(task_input: dict):
+    try:
+        task = OrchestrationEngine.handle_task(task_input)
+        return {"task_id": task.id, "status": task.status}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/agent_orchestrator/app/orchestrator/orchestrator_engine.py
+++ b/agent_orchestrator/app/orchestrator/orchestrator_engine.py
@@ -1,0 +1,9 @@
+from ..kafka.producer import produce_task
+from .task_model import AgentTask
+
+class OrchestrationEngine:
+    @staticmethod
+    def handle_task(task_input: dict) -> AgentTask:
+        task = AgentTask.create(type="GENERIC", input=task_input)
+        produce_task(task)
+        return task


### PR DESCRIPTION
Adds POST /tasks route in agent_orchestrator.
Implements handle_task() in orchestrator_engine.py which builds an AgentTask and publishes it to Kafka.
Manually tested with Invoke-RestMethod from PowerShell — task successfully published to Kafka agent-tasks-inbound topic! :D