### PR TITLE
refactor: enrich agent response with task metadata for downstream processing

### DIFF
--- a/agent_service/app/agent_runner.py
+++ b/agent_service/app/agent_runner.py
@@ -1,3 +1,4 @@
+import time
 from langchain_ollama import ChatOllama
 from langchain_core.messages import HumanMessage
 import os
@@ -7,8 +8,9 @@ from app.logger import setup_logger
 log = setup_logger()
 load_dotenv()
 
-def run_agent(task_input: dict) -> str:
-    log.info(f"[Agent Runner] Received task input: {task_input}")
+
+def run_agent(task_id: str, task_input: dict) -> dict:
+    log.info(f"[Agent Runner] Running agent for task_id={task_id}, input={task_input}")
 
     prompt_text = task_input.get("input") or str(task_input)
 
@@ -19,5 +21,13 @@ def run_agent(task_input: dict) -> str:
     )
 
     response = model.invoke([HumanMessage(content=prompt_text)])
-    log.info(f"[Agent Runner] Final response: {response}")
-    return response.content
+
+    log.info(f"[Agent Runner] Response: {response.content}")
+
+    return {
+        "task_id": task_id,
+        "status": "COMPLETED",
+        "output": response.content,
+        "timestamp": time.time()
+    }
+

--- a/agent_service/app/kafka/consumer.py
+++ b/agent_service/app/kafka/consumer.py
@@ -36,12 +36,10 @@ def blocking_consume_loop():
     from app.kafka.producer import produce_result
 
     for message in consumer:
-        print(f"[Kafka Consumer] Received message: {message.value}")
-        task_id = message.value.get("id")
-        task_input = message.value.get("input")
-
-        result = run_agent(task_input)
-        produce_result({"id": task_id, "result": result})
+        task_data = message.value
+        task_id = task_data.get("id") or "unknown"
+        result = run_agent(task_id, task_data.get("input", {}))
+        produce_result(result)
 
 
 async def consume_kafka_messages():


### PR DESCRIPTION
This PR updates the `agent_service` Kafka consumer and agent runner to support enriched task responses.

`run_agent()` now accepts `task_id` and returns a metadata dict (id, status, output, timestamp)
Kafka consumer in `agent_service` deserializes the task input and produces structured result
Lays groundwork for orchestrator to track completion status and output

This refactor standardizes the agent result format and makes it ready for integration with downstream consumers.
