### PR TITLE
feat: add Kafka consumer for task results and refactor to shared task_store

### DIFF
--- a/agent_orchestrator/app/kafka/consumer.py
+++ b/agent_orchestrator/app/kafka/consumer.py
@@ -4,11 +4,12 @@ import time
 import asyncio
 from kafka import KafkaConsumer
 from kafka.errors import NoBrokersAvailable
+from app.orchestrator.task_store import TASK_STORE
 
 KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
 TOPIC_OUT = os.getenv("TOPIC_OUT", "agent-tasks-completed")
 
-def blocking_result_consume_loop():
+def blocking_result_consume_loop(task_store):
     print(f"[Kafka Consumer] Connecting to broker at {KAFKA_BROKER} to listen on '{TOPIC_OUT}'")
 
     for attempt in range(10):
@@ -29,13 +30,23 @@ def blocking_result_consume_loop():
     else:
         raise RuntimeError("Kafka broker not available after retries")
 
-    from app.orchestrator.orchestrator_engine import update_task_with_result
+    from app.orchestrator.task_model import AgentTask
 
     for message in consumer:
-        print(f"[Kafka Consumer] Received completed task: {message.value}")
-        update_task_with_result(message.value)
+        print(f"[Kafka Consumer] Received message: {message.value}")
+        task_id = message.value.get("task_id")
+        output = message.value.get("output")
+
+        task = task_store.get(task_id)
+        if not task:
+            print(f"[Task Store] No task found with ID: {task_id}")
+            continue
+
+        task.mark_completed(output)
+        print(f"[Task Store] Updated task {task_id} as COMPLETED.")
+
 
 async def consume_kafka_results():
     print("[Consumer] Starting background Kafka consumer for completed tasks...")
     loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, blocking_result_consume_loop)
+    await loop.run_in_executor(None, blocking_result_consume_loop, TASK_STORE)

--- a/agent_orchestrator/app/kafka/consumer.py
+++ b/agent_orchestrator/app/kafka/consumer.py
@@ -1,0 +1,41 @@
+import os
+import json
+import time
+import asyncio
+from kafka import KafkaConsumer
+from kafka.errors import NoBrokersAvailable
+
+KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
+TOPIC_OUT = os.getenv("TOPIC_OUT", "agent-tasks-completed")
+
+def blocking_result_consume_loop():
+    print(f"[Kafka Consumer] Connecting to broker at {KAFKA_BROKER} to listen on '{TOPIC_OUT}'")
+
+    for attempt in range(10):
+        try:
+            consumer = KafkaConsumer(
+                TOPIC_OUT,
+                bootstrap_servers=KAFKA_BROKER,
+                auto_offset_reset='earliest',
+                enable_auto_commit=True,
+                group_id='orchestrator-service-group',
+                value_deserializer=lambda m: json.loads(m.decode('utf-8'))
+            )
+            print("[Kafka Consumer] Connected successfully.")
+            break
+        except NoBrokersAvailable:
+            print(f"[Kafka Consumer] Kafka not available (attempt {attempt + 1}/10). Retrying...")
+            time.sleep(2)
+    else:
+        raise RuntimeError("Kafka broker not available after retries")
+
+    from app.orchestrator.orchestrator_engine import update_task_with_result
+
+    for message in consumer:
+        print(f"[Kafka Consumer] Received completed task: {message.value}")
+        update_task_with_result(message.value)
+
+async def consume_kafka_results():
+    print("[Consumer] Starting background Kafka consumer for completed tasks...")
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, blocking_result_consume_loop)

--- a/agent_orchestrator/app/orchestrator/agent_router.py
+++ b/agent_orchestrator/app/orchestrator/agent_router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
-from ..orchestrator.orchestrator_engine import OrchestrationEngine, task_store
-from ..orchestrator.task_model import AgentTask
+from app.orchestrator.orchestrator_engine import OrchestrationEngine
+from app.orchestrator.task_store import TASK_STORE
 
 router = APIRouter(prefix="/v1")
 
@@ -14,7 +14,7 @@ async def create_task(task_input: dict):
 
 @router.get("/tasks/{task_id}")
 async def get_task(task_id: str):
-    task = task_store.get(task_id)
+    task = TASK_STORE.get(task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return task

--- a/agent_orchestrator/app/orchestrator/orchestrator_engine.py
+++ b/agent_orchestrator/app/orchestrator/orchestrator_engine.py
@@ -1,13 +1,11 @@
 from ..kafka.producer import produce_task
 from .task_model import AgentTask
-from typing import Dict
-
-task_store: Dict[str, AgentTask] = {}
+from app.orchestrator.task_store import TASK_STORE
 
 class OrchestrationEngine:
     @staticmethod
     def handle_task(task_input: dict) -> AgentTask:
         task = AgentTask.create(type="GENERIC", input=task_input)
-        task_store[task.id] = task
+        TASK_STORE[task.id] = task
         produce_task(task)
         return task

--- a/agent_orchestrator/app/orchestrator/orchestrator_engine.py
+++ b/agent_orchestrator/app/orchestrator/orchestrator_engine.py
@@ -1,5 +1,5 @@
-from ..kafka.producer import produce_task
-from .task_model import AgentTask
+from app.kafka.producer import produce_task
+from app.orchestrator.task_model import AgentTask
 from app.orchestrator.task_store import TASK_STORE
 
 class OrchestrationEngine:

--- a/agent_orchestrator/app/orchestrator/task_model.py
+++ b/agent_orchestrator/app/orchestrator/task_model.py
@@ -1,8 +1,9 @@
 from enum import Enum
 from pydantic import BaseModel
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import uuid
 import time
+
 
 class TaskStatus(str, Enum):
     PENDING = "PENDING"
@@ -16,6 +17,11 @@ class AgentTask(BaseModel):
     input: Dict[str, Any]
     status: TaskStatus
     timestamp: float
+    output: Optional[str] = None
+
+    def mark_completed(self, output: str):
+        self.status = TaskStatus.COMPLETED
+        self.output = output
 
     @classmethod
     def create(cls, type: str, input: Dict[str, Any]):

--- a/agent_orchestrator/app/orchestrator/task_store.py
+++ b/agent_orchestrator/app/orchestrator/task_store.py
@@ -1,0 +1,4 @@
+from typing import Dict
+from app.orchestrator.task_model import AgentTask
+
+TASK_STORE: Dict[str, AgentTask] = {}


### PR DESCRIPTION
This PR sets up the Kafka consumer in the `agent_orchestrator` service and introduces a shared in-memory task store.

Changes:
- `app/kafka/consumer.py`: Adds a Kafka consumer that listens to `agent-tasks-completed`, extracts the `task_id` and `output`, and updates the corresponding task's status.
- `task_model.py`: Adds `output: Optional[str]` and `timestamp: float` to the `AgentTask` model; adds `mark_completed()` method.
- Refactors all orchestrator modules (`agent_router.py`, `orchestrator_engine.py`, etc.) to import and use the centralized `TASK_STORE` from the new `task_store.py`.
- `main.py`: Spawns `consume_kafka_results()` in the FastAPI `lifespan` handler for background Kafka consumption.

New:
- `app/orchestrator/task_store.py`: Shared store for in-memory task tracking across orchestrator components.

Purpose:
This completes the downstream task result handling flow: once a result is produced by `agent_service`, it's consumed by the orchestrator and mapped to the relevant in-memory task record via `mark_completed()`.

No API routes are added in this PR — only internal Kafka handling and shared state plumbing.
