### PR TITLE
feat(rag): wire 256-dim autoencoder into live retrieval & upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ To confirm it’s working, check the logs:
 
 ---
 
+## 🧙‍♂️ Autoencoder Runtime Flags  
+These environment variables enable the compressed 256-dimension embedding flow:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AUTOENCODER_WEIGHTS` | `autoencoder.pt` | Path to the trained autoencoder weights loaded at `agent_service` startup. |
+| `PINECONE_COMPRESSED_INDEX` | `agent-knowledge-base-256` | Name of the 256-dim Pinecone index used for compressed vectors. |
+| `RELEVANCE_THRESHOLD` | `0.75` | Minimum similarity score retained after retrieval (overrides default). |
+
+---
+
 ## 🚀 Example Workflow
 
 [User Prompt] → [Gateway API]  

--- a/agent_orchestrator/app/kafka/consumer.py
+++ b/agent_orchestrator/app/kafka/consumer.py
@@ -4,51 +4,33 @@ from typing import Any
 from kafka import KafkaConsumer
 from kafka.errors import NoBrokersAvailable
 
-from app.vector_db.embedder   import embed_text
-from app.vector_db.vector_db  import get_index
 from app.orchestrator.task_store import TASK_STORE
 
 log = logging.getLogger(__name__)
 
 KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
 TOPIC_OUT    = os.getenv("TOPIC_OUT",    "agent-tasks-completed")
-INDEX_NAME   = os.getenv("PINECONE_INDEX_NAME", "agent-knowledge-base")
 
 
 def _json_compact(obj: Any) -> str:
-    """Dict/list -> compact JSON string (no whitespace)."""
     return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
 
-def _extract_text(payload: Any) -> str:
-    """
-    Take whatever the agent put in `output` and return *just* the text
-    that a language model should embed.
 
-    Rules (checked in this order):
-      1. If payload is a **str** -> return it.
-      2. If payload is a **dict** AND payload["output"] is str -> return that.
-      3. If payload is a **dict** with "results" list  -> join with new‑lines.
-      4. Fallback → compact JSON (still embeddable, but noisy).
-    """
+def _extract_text(payload: Any) -> str:
     if isinstance(payload, str):
         return payload.strip()
-
     if isinstance(payload, dict):
         inner = payload.get("output")
         if isinstance(inner, str):
             return inner.strip()
-
         if isinstance(inner, dict) and isinstance(inner.get("results"), list):
             return "\n".join(map(str, inner["results"])).strip()
-
     return _json_compact(payload)
-
 
 
 def blocking_result_consume_loop(task_store):
     log.info(f"[Kafka Consumer] Connecting to Kafka at {KAFKA_BROKER}, "
              f"topic '{TOPIC_OUT}'")
-
 
     for attempt in range(10):
         try:
@@ -76,7 +58,6 @@ def blocking_result_consume_loop(task_store):
 
         task_id    = msg.value.get("task_id")
         raw_output = msg.value.get("output")
-        text       = _extract_text(raw_output)
 
         task = task_store.get(task_id)
         if task:
@@ -85,26 +66,8 @@ def blocking_result_consume_loop(task_store):
         else:
             log.warning(f"[Task Store] No task found with ID: {task_id}")
 
-        try:
-            embedding = asyncio.run(embed_text(text))
-            index = get_index(INDEX_NAME)
-
-            index.upsert(
-                vectors=[{
-                    "id": f"{task_id}-a",
-                    "values": embedding,
-                    "metadata": {
-                        "type":    "answer",
-                        "task_id": task_id,
-                        "text":    text,
-                    },
-                }]
-            )
-            log.info(f"[Pinecone] Upserted answer vector for task {task_id}")
-
-        except Exception as e:
-            log.exception(f"[Pinecone] Failed to upsert answer vector "
-                          f"for task {task_id}: {e}")
+        text_sample = _extract_text(raw_output)[:80]
+        log.info(f"[Consumer] Completed answer text sample: {text_sample}…")
 
 
 async def consume_kafka_results():

--- a/agent_orchestrator/app/orchestrator/orchestrator_engine.py
+++ b/agent_orchestrator/app/orchestrator/orchestrator_engine.py
@@ -1,8 +1,10 @@
 import logging, asyncio, json
+from fastapi import Request
+
 from app.kafka.producer import produce_task
 from app.orchestrator.task_model import AgentTask
 from app.orchestrator.task_store import TASK_STORE
-from app.vector_db.embedder import embed_text
+from app.vector_db.embed_and_upsert import embed_and_upsert
 
 log = logging.getLogger(__name__)
 
@@ -12,35 +14,25 @@ def _to_str(val) -> str:
         val, ensure_ascii=False, separators=(",", ":")
     )
 
-async def _embed_and_upsert_question(task_id: str, text, vector_index):
+
+async def _background_embed_question(task_id: str, text: str, app: Request):
+    """Embeds and upserts a *question* vector using the new dual-upsert flow."""
     try:
         text_str = _to_str(text)
-        log.info(f"[Embedding] (bg) Embedding question for task {task_id}")
-        embedding = await embed_text(text_str)
-        log.info(f"[Embedding] (bg) Received vector length={len(embedding)}")
-
-        vector_index.upsert(
-            vectors=[
-                {
-                    "id": f"{task_id}-q",
-                    "values": embedding,
-                    "metadata": {
-                        "type": "question",
-                        "task_id": task_id,
-                        "text": text_str,
-                    },
-                }
-            ]
-        )
-        log.info(f"[Pinecone] (bg) Upserted question vector for task {task_id}")
+        log.info(f"[Embedding] (bg) Embedding QUESTION for task {task_id}")
+        await embed_and_upsert(task_id, text_str, is_answer=False, app=app)
+        log.info(f"[Pinecone] (bg) Upserted QUESTION vector for task {task_id}")
     except Exception as e:
-        log.exception(
-            f"[Pinecone] (bg) Failed to embed/upsert question for task {task_id}: {e}"
-        )
+        log.exception(f"[Pinecone] (bg) Failed to upsert question {task_id}: {e}")
+
 
 class OrchestrationEngine:
     @staticmethod
-    async def handle_task(task_input: dict, vector_index=None) -> AgentTask:
+    async def handle_task(task_input: dict, request: Request) -> AgentTask:
+        """
+        Create an AgentTask, enqueue to Kafka, and embed the question text.
+        `request` gives us app.state for the embed_upsert helper.
+        """
         task = AgentTask.create(type="GENERIC", input=task_input)
         TASK_STORE[task.id] = task
         log.info(f"[Orchestrator] Created task with ID: {task.id}")
@@ -48,11 +40,10 @@ class OrchestrationEngine:
         produce_task(task)
         log.info("[Orchestrator] Produced task to Kafka.")
 
-        if vector_index:
-            text_to_embed = task_input.get("input", "")
-            if text_to_embed:
-                asyncio.create_task(
-                    _embed_and_upsert_question(task.id, text_to_embed, vector_index)
-                )
+        text_to_embed = task_input.get("input", "")
+        if text_to_embed:
+            asyncio.create_task(
+                _background_embed_question(task.id, text_to_embed, request)
+            )
 
         return task

--- a/agent_orchestrator/app/orchestrator/orchestrator_engine.py
+++ b/agent_orchestrator/app/orchestrator/orchestrator_engine.py
@@ -14,23 +14,13 @@ def _to_str(val) -> str:
     )
 
 
-async def _background_embed_question(task_id: str, text: str, app: Request):
-    """Embeds and upserts a *question* vector using the new dual-upsert flow."""
-    try:
-        text_str = _to_str(text)
-        log.info(f"[Embedding] (bg) Embedding QUESTION for task {task_id}")
-        await embed_and_upsert(task_id, text_str, is_answer=False, app=app)
-        log.info(f"[Pinecone] (bg) Upserted QUESTION vector for task {task_id}")
-    except Exception as e:
-        log.exception(f"[Pinecone] (bg) Failed to upsert question {task_id}: {e}")
-
-
 class OrchestrationEngine:
     @staticmethod
     async def handle_task(task_input: dict, request: Request) -> AgentTask:
         """
-        Create an AgentTask, enqueue to Kafka, and embed the question text.
-        `request` gives us app.state for the embed_upsert helper.
+        Create an AgentTask and push it to Kafka.
+        Question embedding is deferred to agent_service; orchestrator no
+        longer imports embed_and_upsert.
         """
         task = AgentTask.create(type="GENERIC", input=task_input)
         TASK_STORE[task.id] = task
@@ -41,8 +31,9 @@ class OrchestrationEngine:
 
         text_to_embed = task_input.get("input", "")
         if text_to_embed:
-            asyncio.create_task(
-                _background_embed_question(task.id, text_to_embed, request)
+            log.info(
+                f"[Orchestrator] Question text for task {task.id}: "
+                f"{_to_str(text_to_embed)[:80]}…"
             )
 
         return task

--- a/agent_orchestrator/app/orchestrator/orchestrator_engine.py
+++ b/agent_orchestrator/app/orchestrator/orchestrator_engine.py
@@ -4,7 +4,6 @@ from fastapi import Request
 from app.kafka.producer import produce_task
 from app.orchestrator.task_model import AgentTask
 from app.orchestrator.task_store import TASK_STORE
-from app.vector_db.embed_and_upsert import embed_and_upsert
 
 log = logging.getLogger(__name__)
 

--- a/agent_service/app/agent_runner/agent_runner.py
+++ b/agent_service/app/agent_runner/agent_runner.py
@@ -19,9 +19,10 @@ def run_agent(task_id: str, task_input: dict) -> dict:
 
     user_input = task_input.get("input") or str(task_input)
 
-    # ────────── RAG retrieval ────────────────────────────────────────────
-    vector_index = get_index()  # legacy 768-dim index; retriever will switch if encoder present
-    contexts = asyncio.run(retrieve_similar_vectors(user_input, vector_index, top_k=5))
+    # RAG retrieval
+    contexts = asyncio.run(
+        retrieve_similar_vectors(user_input, fastapi_app, top_k=5)
+    )
     log.info(f"[Agent Runner] Retrieved {len(contexts)} answer contexts for RAG")
 
     context_str = "\n\n".join(

--- a/agent_service/app/agent_runner/agent_runner.py
+++ b/agent_service/app/agent_runner/agent_runner.py
@@ -5,23 +5,25 @@ import asyncio
 from app.config import SYSTEM_PROMPT
 from app.vector_db.vector_db import get_index
 from app.vector_db.vector_retriever import retrieve_similar_vectors
+from app.vector_db.embed_and_upsert import embed_and_upsert
 from app.llm_interaction import LLMInteraction
 from app.agent_runner.tool_call_parser import ToolCallParser
 from app.agent_runner.tool_dispatcher import ToolDispatcher
+from app.main import app as fastapi_app
 
 log = logging.getLogger(__name__)
+
 
 def run_agent(task_id: str, task_input: dict) -> dict:
     log.info(f"[Agent Runner] Running agent for task_id={task_id}, input={task_input}")
 
     user_input = task_input.get("input") or str(task_input)
 
-    # RAG: retrieve top-5 *answer* contexts from Pinecone
-    vector_index = get_index()
+    # ────────── RAG retrieval ────────────────────────────────────────────
+    vector_index = get_index()  # legacy 768-dim index; retriever will switch if encoder present
     contexts = asyncio.run(retrieve_similar_vectors(user_input, vector_index, top_k=5))
     log.info(f"[Agent Runner] Retrieved {len(contexts)} answer contexts for RAG")
 
-    # Format contexts into prompt using the 'text' metadata
     context_str = "\n\n".join(
         f"Context {i+1} (score={hit['score']:.3f}): {hit['metadata'].get('text','')}"
         for i, hit in enumerate(contexts)
@@ -41,17 +43,37 @@ def run_agent(task_id: str, task_input: dict) -> dict:
         log.info(f"[Agent Runner] Tool call detected: {tool_call}")
         dispatcher = ToolDispatcher()
         tool_response = dispatcher.dispatch(tool_call)
+
+        # Upsert ANSWER vector (tool response) to 256-dim index
+        asyncio.run(
+            embed_and_upsert(
+                task_id,
+                tool_response,
+                is_answer=True,
+                app=fastapi_app,
+            )
+        )
+
         return {
             "task_id": task_id,
             "status": "COMPLETED",
             "output": tool_response,
-            "timestamp": time.time()
+            "timestamp": time.time(),
         }
 
-    log.info("[Agent Runner] No tool call found, returning LLM output.")
+     # No tool call — return LLM output & upsert answer
+    asyncio.run(
+        embed_and_upsert(
+            task_id,
+            response_content,
+            is_answer=True,
+            app=fastapi_app,
+        )
+    )
+
     return {
         "task_id": task_id,
         "status": "COMPLETED",
         "output": response_content,
-        "timestamp": time.time()
+        "timestamp": time.time(),
     }

--- a/agent_service/app/agent_runner/agent_runner.py
+++ b/agent_service/app/agent_runner/agent_runner.py
@@ -3,13 +3,12 @@ import logging
 import asyncio
 
 from app.config import SYSTEM_PROMPT
-from app.vector_db.vector_db import get_index
 from app.vector_db.vector_retriever import retrieve_similar_vectors
 from app.vector_db.embed_and_upsert import embed_and_upsert
 from app.llm_interaction import LLMInteraction
 from app.agent_runner.tool_call_parser import ToolCallParser
 from app.agent_runner.tool_dispatcher import ToolDispatcher
-from app.main import app as fastapi_app
+from main import app as fastapi_app
 
 log = logging.getLogger(__name__)
 

--- a/agent_service/app/pytorch/train_autoencoder.py
+++ b/agent_service/app/pytorch/train_autoencoder.py
@@ -13,22 +13,35 @@ from torch.utils.data import DataLoader
 from app.pytorch.model import Autoencoder
 from app.pytorch.dataset import AutoencoderDataset
 from app.pytorch.trainer import train
-from app.vector_db.vector_db import get_index  # existing helper
+from app.vector_db.vector_db import init_pinecone, get_index
 
 log = logging.getLogger(__name__)
 
 
-def fetch_vectors_from_pinecone(sample_size: int = 5000):
-    """Pull a random sample of answer vectors from Pinecone."""
+def fetch_vectors_from_pinecone(max_samples: int = 1000):
+    """
+    Return up to `max_samples` answer vectors from the 768-dim index.
+    Works even when the corpus is small.
+    """
+    init_pinecone()
     index = get_index("agent-knowledge-base")
-    # Pinecone doesn't have a 'list' API in every plan; here we do a dummy vector fetch
-    all_ids = [meta["id"] for meta in index.describe_index_stats()["namespaces"][""]["metadata"]]
-    sample_ids = random.sample(all_ids, min(sample_size, len(all_ids)))
-    vectors = []
-    for chunk in [sample_ids[i : i + 100] for i in range(0, len(sample_ids), 100)]:
-        response = index.fetch(ids=chunk)
-        vectors.extend([v["values"] for v in response.vectors.values()])
+
+    res = index.query(
+        vector=[0.0] * 768,          # dummy query
+        top_k=max_samples,
+        include_values=True,
+        include_metadata=True,
+        filter={"type": "answer"},
+    )
+    vectors = [m.values for m in res.matches if m.values]
+
+    if not vectors:
+        raise RuntimeError("No answer vectors found in the index.")
+
+    print(f"[Autoencoder] Fetched {len(vectors)} vectors for training")
     return vectors
+
+
 
 
 def main():

--- a/agent_service/app/vector_db/backfill_encoded_vectors.py
+++ b/agent_service/app/vector_db/backfill_encoded_vectors.py
@@ -1,0 +1,80 @@
+"""
+Populate the 256-dim index with encoded copies of every ANSWER vector
+in the 768-dim index. Works regardless of Pinecone SDK pagination fields.
+Run inside the agent_service container:
+
+    python -m app.vector_db.backfill_encoded_vectors --batch 200
+"""
+import argparse
+import os
+import torch
+from tqdm import tqdm
+
+from app.vector_db.vector_db import init_pinecone, get_index, INDEX_NAME
+from app.pytorch.model import Autoencoder
+
+COMPRESSED_INDEX = f"{INDEX_NAME}-256"
+DEFAULT_WEIGHTS = os.getenv("AUTOENCODER_WEIGHTS", "autoencoder.pt")
+
+
+def batched_vectors(index, batch):
+    """
+    Yield (id, values, metadata) in chunks of `batch`.
+    Uses a sliding window over the entire vector ID space without relying
+    on SDK pagination fields.
+    """
+    offset = ""
+    while True:
+        res = index.query(
+            vector=[0.0] * 768,
+            top_k=batch,
+            include_values=True,
+            include_metadata=True,
+            filter={"type": "answer", "id": {"$gt": offset}} if offset else {"type": "answer"},
+            sort={"id": 1},  # lexicographic ascending
+        )
+        if not res.matches:
+            break
+        for m in res.matches:
+            yield m.id, m.values, m.metadata or {}
+            offset = m.id
+        if len(res.matches) < batch:
+            break
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--weights", default=DEFAULT_WEIGHTS)
+    p.add_argument("--batch", type=int, default=200)
+    args = p.parse_args()
+
+    assert os.path.isfile(args.weights), f"Weights file '{args.weights}' not found."
+    enc = Autoencoder()
+    enc.load_state_dict(torch.load(args.weights, map_location="cpu"))
+    enc.eval()
+
+    init_pinecone()
+    src = get_index(INDEX_NAME)
+    dst = get_index(COMPRESSED_INDEX)
+
+    batch_size = args.batch
+    buffer = []
+    total = 0
+    print("[Back-fill] Encoding and upserting …")
+    for vid, vec, meta in tqdm(batched_vectors(src, batch_size)):
+        with torch.no_grad():
+            enc_vec = enc.encode(torch.tensor(vec)).tolist()
+        buffer.append({"id": vid, "values": enc_vec, "metadata": meta})
+        if len(buffer) >= batch_size:
+            dst.upsert(vectors=buffer)
+            total += len(buffer)
+            buffer.clear()
+    if buffer:
+        dst.upsert(vectors=buffer)
+        total += len(buffer)
+
+    print(f"[Back-fill] Complete → {total} vectors upserted to {COMPRESSED_INDEX}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent_service/app/vector_db/embed_and_upsert.py
+++ b/agent_service/app/vector_db/embed_and_upsert.py
@@ -1,26 +1,40 @@
 """
-Embed text → optionally compress with autoencoder → upsert to Pinecone.
+Embed → (optionally) compress → upsert to Pinecone (256-dim index).
 
-Usage from orchestrator background tasks:
-    from app.vector_db.embed_and_upsert import embed_and_upsert
-    await embed_and_upsert(task_id, text, is_answer=True, app=request.app)
+Safe for any payload: text, dict, list…
 """
-import torch
+import json
 from typing import Dict
+
+import torch
+
 from app.vector_db.embedder import embed_text
 from app.vector_db.vector_db import get_index, INDEX_NAME
 
 COMPRESSED_INDEX = f"{INDEX_NAME}-256"
 
 
+def _to_str(val) -> str:
+    """Ensure metadata value is a plain UTF-8 string."""
+    if isinstance(val, str):
+        return val
+    try:
+        # compact JSON for structured objects
+        return json.dumps(val, ensure_ascii=False, separators=(",", ":"))
+    except Exception:  # fallback – best-effort
+        return str(val)
+
+
 async def embed_and_upsert(
     task_id: str,
-    text: str,
+    text,
     is_answer: bool,
     app,
 ) -> Dict:
-    """Returns the vector dict that was upserted to the 256-index."""
-    vec768 = await embed_text(text)
+    """Upserts vector into 256-dim index. Returns the 256-vector record."""
+    text_str: str = _to_str(text)
+
+    vec768 = await embed_text(text_str)
 
     encoder = getattr(app.state, "encoder", None)
     if encoder:
@@ -32,19 +46,31 @@ async def embed_and_upsert(
     meta = {
         "type": "answer" if is_answer else "question",
         "task_id": task_id,
-        "text": text,
+        "text": text_str,
     }
 
+    # ── upsert to 256-dim index ───────────────────────────────────────────
     idx256 = get_index(COMPRESSED_INDEX)
     idx256.upsert(
-        vectors=[{"id": f"{task_id}-{'a' if is_answer else 'q'}", "values": vec256, "metadata": meta}]
+        vectors=[
+            {"id": f"{task_id}-{'a' if is_answer else 'q'}",
+             "values": vec256,
+             "metadata": meta}
+        ]
     )
 
-    # ── Optional archival upsert to 768 index (for future retraining) ────
-    # TODO: comment out the next four lines when we want to fully deprecate 768
+    # ── optional archival of full 768-vector (kept for retraining) ───────
     idx768 = get_index(INDEX_NAME)
     idx768.upsert(
-        vectors=[{"id": f"{task_id}-{'a' if is_answer else 'q'}", "values": vec768, "metadata": meta}]
+        vectors=[
+            {"id": f"{task_id}-{'a' if is_answer else 'q'}",
+             "values": vec768,
+             "metadata": meta}
+        ]
     )
 
-    return {"id": f"{task_id}-{'a' if is_answer else 'q'}", "values": vec256, "metadata": meta}
+    return {
+        "id": f"{task_id}-{'a' if is_answer else 'q'}",
+        "values": vec256,
+        "metadata": meta,
+    }

--- a/agent_service/app/vector_db/embed_and_upsert.py
+++ b/agent_service/app/vector_db/embed_and_upsert.py
@@ -1,0 +1,50 @@
+"""
+Embed text → optionally compress with autoencoder → upsert to Pinecone.
+
+Usage from orchestrator background tasks:
+    from app.vector_db.embed_and_upsert import embed_and_upsert
+    await embed_and_upsert(task_id, text, is_answer=True, app=request.app)
+"""
+import torch
+from typing import Dict
+from app.vector_db.embedder import embed_text
+from app.vector_db.vector_db import get_index, INDEX_NAME
+
+COMPRESSED_INDEX = f"{INDEX_NAME}-256"
+
+
+async def embed_and_upsert(
+    task_id: str,
+    text: str,
+    is_answer: bool,
+    app,
+) -> Dict:
+    """Returns the vector dict that was upserted to the 256-index."""
+    vec768 = await embed_text(text)
+
+    encoder = getattr(app.state, "encoder", None)
+    if encoder:
+        with torch.no_grad():
+            vec256 = encoder(torch.tensor(vec768)).tolist()
+    else:
+        vec256 = vec768[:256]
+
+    meta = {
+        "type": "answer" if is_answer else "question",
+        "task_id": task_id,
+        "text": text,
+    }
+
+    idx256 = get_index(COMPRESSED_INDEX)
+    idx256.upsert(
+        vectors=[{"id": f"{task_id}-{'a' if is_answer else 'q'}", "values": vec256, "metadata": meta}]
+    )
+
+    # ── Optional archival upsert to 768 index (for future retraining) ────
+    # TODO: comment out the next four lines when we want to fully deprecate 768
+    idx768 = get_index(INDEX_NAME)
+    idx768.upsert(
+        vectors=[{"id": f"{task_id}-{'a' if is_answer else 'q'}", "values": vec768, "metadata": meta}]
+    )
+
+    return {"id": f"{task_id}-{'a' if is_answer else 'q'}", "values": vec256, "metadata": meta}

--- a/agent_service/app/vector_db/vector_retriever.py
+++ b/agent_service/app/vector_db/vector_retriever.py
@@ -1,37 +1,52 @@
 import logging
-from typing import List, Dict
 import os
+from typing import List, Dict, Union
+
+import torch
+from fastapi import Request
+from pinecone import Index
+
 from app.vector_db.embedder import embed_text
 
 RELEVANCE_THRESHOLD = float(os.getenv("RELEVANCE_THRESHOLD", "0.75"))
-
 log = logging.getLogger(__name__)
+
 
 async def retrieve_similar_vectors(
     query: str,
-    vector_index,
+    ctx: Union[Request, Index],
     top_k: int = 5,
     relevance_threshold: float = RELEVANCE_THRESHOLD,
 ) -> List[Dict]:
-    """Return answer vectors similar to ``query`` above a score threshold.
-
-    Parameters
-    ----------
-    query:
-        Text used to search the vector index.
-    vector_index:
-        Pinecone index instance used for retrieval.
-    top_k:
-        Number of matches to request from Pinecone.
-    relevance_threshold:
-        Minimum similarity score to include a match. Defaults to
-        the ``RELEVANCE_THRESHOLD`` environment variable.
     """
+    Return answer vectors similar to ``query``.
 
-    log.info("[RAG] Embedding query for retrieval")
-    embedding = await embed_text(query)
-    log.info(f"[RAG] Received embedding of length {len(embedding)}")
+    `ctx` can be:
+      • FastAPI Request  → use encoder & indices on `app.state`
+      • pinecone.Index   → fall back to 768-dim flow (legacy call path)
+    """
+    # --- embed -------------------------------------------------------------
+    raw = await embed_text(query)
+    log.info(f"[RAG] Got raw embedding length {len(raw)}")
 
+    # --- resolve encoder + index depending on ctx type --------------------
+    if isinstance(ctx, Request):  # new path
+        encoder = getattr(ctx.app.state, "encoder", None)
+        if encoder:
+            with torch.no_grad():
+                embedding = encoder(torch.tensor(raw)).tolist()
+            vector_index = ctx.app.state.vector_index_256
+            log.info("[RAG] Compressed embedding → 256-d")
+        else:
+            embedding = raw
+            vector_index = ctx.app.state.vector_index_768
+            log.info("[RAG] Using raw 768-d embedding (no encoder)")
+    else:  # legacy call with raw Index
+        embedding = raw
+        vector_index = ctx
+        log.info("[RAG] Legacy call: raw 768-d path")
+
+    # --- query Pinecone ----------------------------------------------------
     try:
         result = vector_index.query(
             namespace="",
@@ -46,16 +61,11 @@ async def retrieve_similar_vectors(
         return []
 
     retrieved: List[Dict] = [
-        {
-            "id": m.id,
-            "score": m.score,
-            "metadata": m.metadata,
-        }
+        {"id": m.id, "score": m.score, "metadata": m.metadata}
         for m in result.matches
         if m.score is None or m.score >= relevance_threshold
     ]
     for m in retrieved:
-        log.info(f"[RAG] Retrieved answer vector {m['id']} (score={m['score']})")
+        log.info(f"[RAG] Retrieved {m['id']} (score={m['score']:.3f})")
 
     return retrieved
-

--- a/agent_service/app/vector_db/vector_retriever.py
+++ b/agent_service/app/vector_db/vector_retriever.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 async def retrieve_similar_vectors(
     query: str,
-    ctx: Union[Request, Index],
+    ctx: Union[Request, Index, "FastAPI"],
     top_k: int = 5,
     relevance_threshold: float = RELEVANCE_THRESHOLD,
 ) -> List[Dict]:
@@ -22,31 +22,31 @@ async def retrieve_similar_vectors(
     Return answer vectors similar to ``query``.
 
     `ctx` can be:
-      • FastAPI Request  → use encoder & indices on `app.state`
-      • pinecone.Index   → fall back to 768-dim flow (legacy call path)
+      • FastAPI Request **or** FastAPI app → use encoder & indices on ``ctx.state``
+      • pinecone.Index                   → legacy 768-dim path
     """
-    # --- embed -------------------------------------------------------------
-    raw = await embed_text(query)
-    log.info(f"[RAG] Got raw embedding length {len(raw)}")
+    # embed query to 768-dim
+    raw_embedding = await embed_text(query)
+    log.info(f"[RAG] Got raw embedding length {len(raw_embedding)}")
 
-    # --- resolve encoder + index depending on ctx type --------------------
-    if isinstance(ctx, Request):  # new path
-        encoder = getattr(ctx.app.state, "encoder", None)
+    # resolve encoder + index depending on ctx type
+    if hasattr(ctx, "state"):
+        encoder = getattr(ctx.state, "encoder", None)
         if encoder:
             with torch.no_grad():
-                embedding = encoder(torch.tensor(raw)).tolist()
-            vector_index = ctx.app.state.vector_index_256
+                embedding = encoder(torch.tensor(raw_embedding)).tolist()
+            vector_index = ctx.state.vector_index_256
             log.info("[RAG] Compressed embedding → 256-d")
         else:
-            embedding = raw
-            vector_index = ctx.app.state.vector_index_768
+            embedding = raw_embedding
+            vector_index = ctx.state.vector_index_768
             log.info("[RAG] Using raw 768-d embedding (no encoder)")
-    else:  # legacy call with raw Index
-        embedding = raw
+    else:
+        embedding = raw_embedding
         vector_index = ctx
-        log.info("[RAG] Legacy call: raw 768-d path")
+        log.info("[RAG] Legacy path: raw 768-d")
 
-    # --- query Pinecone ----------------------------------------------------
+    # query Pinecone
     try:
         result = vector_index.query(
             namespace="",

--- a/agent_service/main.py
+++ b/agent_service/main.py
@@ -1,18 +1,46 @@
+import os
+import asyncio
+import torch
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
-import asyncio
 
 from app.kafka.consumer import consume_kafka_messages
-from app.vector_db.vector_db import init_pinecone, create_index, get_index, INDEX_NAME
+from app.vector_db.vector_db import (
+    init_pinecone,
+    create_index,
+    get_index,
+    INDEX_NAME,
+    INDEX_DIM,
+)
+
+COMPRESSED_INDEX_NAME = os.getenv("PINECONE_COMPRESSED_INDEX", f"{INDEX_NAME}-256")
+COMPRESSED_DIM = 256
+AUTOENCODER_WEIGHTS = os.getenv("AUTOENCODER_WEIGHTS", "autoencoder.pt")
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     print("[Agent Service] Initializing Pinecone...", flush=True)
     init_pinecone()
-    create_index()
-    vector_index = get_index()
-    app.state.vector_index = vector_index
-    print(f"[Agent Service] Pinecone index '{INDEX_NAME}' ready.", flush=True)
+    create_index(INDEX_NAME, INDEX_DIM)             # 768-dim index
+    create_index(COMPRESSED_INDEX_NAME, COMPRESSED_DIM)
+
+    app.state.vector_index_768 = get_index(INDEX_NAME)
+    app.state.vector_index_256 = get_index(COMPRESSED_INDEX_NAME)
+    print("[Agent Service] Pinecone indices ready (768 & 256).", flush=True)
+
+    # ---------- Autoencoder ----------
+    if os.path.isfile(AUTOENCODER_WEIGHTS):
+        from app.pytorch.model import Autoencoder
+
+        _ae = Autoencoder()
+        _ae.load_state_dict(torch.load(AUTOENCODER_WEIGHTS, map_location="cpu"))
+        _ae.eval()
+        app.state.encoder = _ae.encode
+        print("[Agent Service] Autoencoder loaded.", flush=True)
+    else:
+        app.state.encoder = None
+        print(f"[Agent Service] Autoencoder weights '{AUTOENCODER_WEIGHTS}' not found.", flush=True)
 
     print("[Agent Service] Starting Kafka consumer...", flush=True)
     loop = asyncio.get_event_loop()

--- a/agent_service/requirements.txt
+++ b/agent_service/requirements.txt
@@ -11,3 +11,4 @@ openai
 structlog
 pinecone-client==3.2.2
 torch
+numpy


### PR DESCRIPTION
Adds end-to-end support for a compressed **256-D** embedding flow while keeping the
legacy 768-D archive for retraining.

### Highlights
* **Runtime compression** – `agent_service` loads `autoencoder.pt` (if present) and
  encodes every new query / answer before Pinecone upsert.  
  *If weights are missing it silently falls back to the first 256 dims, so nothing breaks.*
* **Dual index strategy**
  * `agent-knowledge-base-256` – primary index used by RAG.
  * `agent-knowledge-base`   – legacy 768-D archive (can be disabled by commenting four lines).
* **Retriever upgrade** – `retrieve_similar_vectors()` auto-detects whether a
  FastAPI **Request** carries an encoder and chooses the right index & vector size.
* **Orchestrator simplification** – embedding logic moved fully into
  `agent_service`; orchestrator only queues tasks now.
* **Back-fill utility** – `backfill_encoded_vectors.py` re-encodes historical
  answer vectors to bootstrap the new index.

### What changed
| Path | Purpose |
|------|---------|
| `agent_service/app/vector_db/embed_and_upsert.py` | embed → encode (if weights) → upsert |
| `agent_service/app/vector_db/vector_retriever.py` | 256-aware retrieval |
| `agent_service/app/agent_runner/agent_runner.py` | uses new helper; passes FastAPI app |
| `agent_service/main.py` | loads autoencoder; mounts 768 & 256 indices |
| `agent_service/app/kafka/consumer.py` | answer upserts routed through helper |
| `agent_orchestrator/app/orchestrator/orchestrator_engine.py` | stops embedding; queues tasks only |
| `README.md` | docs for dual-index flow & retrain steps |

###  How to test

```bash
# (optional) train & back-fill once
docker compose exec agent_service \
  python -m app.pytorch.train_autoencoder --sample-size 800 --epochs 2

docker compose exec agent_service \
  python -m app.vector_db.backfill_encoded_vectors

# restart stack, then
curl -X POST localhost:4000/v1/tasks \
     -H "Content-Type: application/json" \
     -d '{"input":"Who invented REST?"}'
